### PR TITLE
Fix maxVersion in install.rdf

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -17,14 +17,14 @@
       <Description>
       <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
       <em:minVersion>28.14.0</em:minVersion>
-      <em:maxVersion>29.*</em:maxVersion>
+      <em:maxVersion>33.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>52.9.2020.10.05</em:minVersion>
-        <em:maxVersion>52.9.2022.*</em:maxVersion>
+        <em:maxVersion>52.9.2023.*</em:maxVersion>
       </Description>
     </em:targetApplication>
     <em:targetApplication>


### PR DESCRIPTION
The fast fix to stay in compliance with the latest pale moon 31+
* While "<em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>" obviously is the browser version, I don't know about "<em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>" and did the blind fix. Just "to work for me, right now".
You can, of course, decline my patch and do all the things in more correct way.

Regards.